### PR TITLE
Fixed deprecated path.existsSync to fs.existsSync

### DIFF
--- a/lib/systatic.iced
+++ b/lib/systatic.iced
@@ -17,7 +17,7 @@ exports.config = config = ()->
   @configData = require(path.resolve(join('.', 'config.json')))
 
 exports.inProject = (dirname)->
-  return true if path.existsSync(join(dirname, 'config.json'))
+  return true if fs.existsSync(join(dirname, 'config.json'))
   false
 
 exports.clone = (dirname, template)->

--- a/lib/systatic.iced
+++ b/lib/systatic.iced
@@ -1,7 +1,7 @@
 log        = console.log
 {join}     = require('path')
 path       = require('path')
-fs	       = requuire('fs')
+fs	       = require('fs')
 jade       = require(path.join(__dirname, 'plugins', 'jade_template'))
 servitude  = require('servitude')
 bricks     = require('bricks')

--- a/lib/systatic.iced
+++ b/lib/systatic.iced
@@ -1,6 +1,7 @@
 log        = console.log
 {join}     = require('path')
 path       = require('path')
+fs	       = requuire('fs')
 jade       = require(path.join(__dirname, 'plugins', 'jade_template'))
 servitude  = require('servitude')
 bricks     = require('bricks')

--- a/package.json
+++ b/package.json
@@ -13,27 +13,27 @@
   "license" : "MIT/X11",
   "main": "./lib/systatic.coffee",
   "engines": {
-    "node": "~>0.6.0"
+    "node": "~>0.8.2"
   },
   "dependencies": {
-    "iced-coffee-script" : "~>1.3.3a",
-    "optimist"        : "~>0.2.0",
-    "node-fs"         : "~>0.1.3",
-    "wrench"          : "~>1.3.8",
-    "bricks"          : "~>1.1.4",
-    "servitude"       : "~>0.2.0",
-    "coffee-script"   : "~>1.3.3",
-    "jade"            : "~>0.21.0",
-    "less"            : "~>1.3.0",
-    "bricks"          : "~>1.1.4",
-    "underscore"      : "~>1.3.1",
-    "uglify-js"       : "~>1.2.6",
-    "clean-css"       : "~>0.3.2",
-    "compress-buffer" : "~>0.5.1",
-    "noxmox"          : "~>0.1.8"
+    "iced-coffee-script" : "*",
+    "optimist"        : "*",
+    "node-fs"         : "*",
+    "wrench"          : "*",
+    "bricks"          : "*",
+    "servitude"       : "*",
+    "coffee-script"   : "*",
+    "jade"            : "*",
+    "less"            : "*",
+    "bricks"          : "*",
+    "underscore"      : "*",
+    "uglify-js"       : "*",
+    "clean-css"       : "*",
+    "compress-buffer" : "*",
+    "noxmox"          : "*"
   },
   "devDependencies": {
-    "vows": ">=0.5.0"
+    "vows": "*"
   },
   "directories": {
     "test": "./test",


### PR DESCRIPTION
Since `path.existsSync` was deprecated in node 0.8.x, I simply replaced to relevant function `fs.existsSync`. 
